### PR TITLE
Prevent console.log's in production

### DIFF
--- a/js/map_layer.js
+++ b/js/map_layer.js
@@ -35,7 +35,7 @@ techMapApp.controller('TechMapLayerController', function ($scope, $rootScope) {
         var features = convertDataFromGoogleSpreadsheetsJson(data);
         $rootScope.$broadcast('DataAvailable', features);
 
-        console.log(features);
+        $rootScope.debug_message(features);
     });
 
     var lastMarkerSet = null;
@@ -45,7 +45,7 @@ techMapApp.controller('TechMapLayerController', function ($scope, $rootScope) {
     });
 
     $rootScope.$on('EntrySetAvailable', function (event, features) {
-        console.log("New data available");
+        $rootScope.debug_message("New data available");
         
         if (lastMarkerSet != null) {
             map.removeLayer(lastMarkerSet);
@@ -67,7 +67,7 @@ techMapApp.controller('TechMapLayerController', function ($scope, $rootScope) {
                 return { color: feature.properties.color };
             },
             onEachFeature: function (feature, layer) {
-                console.log(feature.properties.title);
+                $rootScope.debug_message(feature.properties.title);
                 var popupText = "";
                 if (feature.properties.color) {
                     popupText += feature.properties.title;
@@ -97,7 +97,7 @@ techMapApp.controller('TechMapLayerController', function ($scope, $rootScope) {
 
                 $rootScope.$on('MarkerSelectedEvent', function (event, featureReceived) {
                     if (feature.properties.title == featureReceived.properties.title) {
-                        console.log("Return");
+                        $rootScope.debug_message("Return");
                         return;
                     }
                     marker.selected = false;

--- a/js/techmap.js
+++ b/js/techmap.js
@@ -1,4 +1,12 @@
-var techMapApp = angular.module('techMapApp', []);
+var techMapApp = angular.module('techMapApp', [])
+    .run(function($rootScope){
+        var debug = false;
+
+        // Log messages only if debugging mode is on
+        $rootScope.debug_message = function(msg){
+            if (debug) console.log(msg)
+        }
+    });
 
 techMapApp.controller('TechMapController', function ($scope) {
 
@@ -46,7 +54,7 @@ techMapApp.controller('TechMapFilterController', function ($scope, $rootScope) {
                 return category.name;
             });
 
-            console.log(_.map(foundCategories, function (category) {
+            $rootScope.debug_message(_.map(foundCategories, function (category) {
                 return category.name;
             }).join("\n"));
 
@@ -75,7 +83,7 @@ techMapApp.controller('TechMapFilterController', function ($scope, $rootScope) {
     }
 
     $scope.$watch('filter.category', function (newValue, oldValue) {
-        console.log(newValue);
+        $rootScope.debug_message(newValue);
 
         if (fullInitialFeatures == null) {
             return;
@@ -93,7 +101,7 @@ techMapApp.controller('TechMapFilterController', function ($scope, $rootScope) {
     });
     
     $scope.$watch('filter.type', function (newValue, oldValue) {
-        console.log(newValue);
+        $rootScope.debug_message(newValue);
 
         if (fullInitialFeatures == null) {
             return;
@@ -150,7 +158,7 @@ techMapApp.controller('TechMapSummaryController', function ($scope, $rootScope, 
 
 techMapApp.controller('TechMapSideMenuController', function ($scope, $rootScope) {
     $scope.$on('MarkerSelectedEvent', function (event, feature) {
-        console.log(feature);
+        $rootScope.debug_message(feature);
         if ($scope.selectedObject == feature.properties) {
             $scope.selectedObject = null;
         } else {


### PR DESCRIPTION
Quick and minor fix to prevent 121 messages showing up in production.

Wraps all console.log's with a simple function that enables debugging mode.

In production, always should stand as 

``` js
var debug = false
```
